### PR TITLE
Fix publiccode.yml screenshot URL

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -34,8 +34,7 @@ description:
 
       l’igiene delle mani.
     screenshots:
-      - |-
-        https://raw.githubusercontent.com/RegioneER/mapper/master/MaAppERscreenshot.jpg
+      - MaAppERscreenshot.jpg
     shortDescription: Applicazione per il monitoraggio dell'igiene delle mani
 developmentStatus: stable
 it:


### PR DESCRIPTION
Buongiorno @msnetadmin @tassoman,

questa PR corregge la URL degli screenshot riportando una path relativo alla root del repo.

Resto a disposizione, grazie